### PR TITLE
SAXException: Invalid UTF-16 surrogate detected: d800 ? 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/.idea/
+/.settings/
+/build/
+/src/org/apache/xalan/xsltc/compiler/sym.java
+/src/org/apache/xalan/xsltc/compiler/XPathLexer.java
+/src/org/apache/xalan/xsltc/compiler/XPathParser.java
+/src/org/apache/xalan/processor/XSLProcessorVersion.java

--- a/src/org/apache/xml/serializer/ToHTMLStream.java
+++ b/src/org/apache/xml/serializer/ToHTMLStream.java
@@ -1061,7 +1061,7 @@ public class ToHTMLStream extends ToStream
         String name,
         String value,
         ElemDesc elemDesc)
-        throws IOException
+        throws IOException, SAXException
     {
         writer.write(' ');
 
@@ -1385,7 +1385,7 @@ public class ToHTMLStream extends ToStream
      */
     public void writeAttrString(
         final java.io.Writer writer, String string, String encoding)
-        throws IOException
+        throws IOException, SAXException
     {
         final int end = string.length();
         if (end > m_attrBuff.length)
@@ -1437,13 +1437,16 @@ public class ToHTMLStream extends ToStream
                 }
                 else
                 {
-                    if (Encodings.isHighUTF16Surrogate(ch))
+                    if (Encodings.isHighUTF16Surrogate(ch) ||
+                            Encodings.isLowUTF16Surrogate(ch))
                     {
- 
-                            writeUTF16Surrogate(ch, chars, i, end);
-                            i++; // two input characters processed
-                                 // this increments by one and the for()
-                                 // loop itself increments by another one.
+                        if (writeUTF16Surrogate(ch, chars, i, end) >= 0) {
+                            // move the index if the low surrogate is consumed
+                            // as writeUTF16Surrogate has written the pair
+                            if (Encodings.isHighUTF16Surrogate(ch)) {
+                                i++;
+                            }
+                        }
                     }
 
                     // The next is kind of a hack to keep from escaping in the case 

--- a/src/org/apache/xml/serializer/ToStream.java
+++ b/src/org/apache/xml/serializer/ToStream.java
@@ -773,6 +773,7 @@ abstract public class ToStream extends SerializerBase
 
     }
 
+    private char m_highSurrogate = 0;
 
     /**
      * Might print a newline character and the indentation amount
@@ -963,7 +964,7 @@ abstract public class ToStream extends SerializerBase
      * represented by the high/low surrogate pair.
      * <p>
      * An exception is thrown if there is no low surrogate in the pair,
-     * because the array ends unexpectely, or if the low char is there
+     * because the array ends unexpectedly, or if the low char is there
      * but its value is such that it is not a low surrogate.
      *
      * @param c the first (high) part of the surrogate, which
@@ -971,45 +972,46 @@ abstract public class ToStream extends SerializerBase
      * @param ch Character array.
      * @param i position Where the surrogate was detected.
      * @param end The end index of the significant characters.
-     * @return 0 if the pair of characters was written out as-is,
-     * the unicode code point of the character represented by
-     * the surrogate pair if an entity reference with that value
-     * was written out. 
-     * 
+     * @return the status of writing a surrogate pair.
+     *        -1 -- nothing is written
+     *         0 -- the pair is written as-is
+     *         code point -- the pair is written as an entity reference
+     *
      * @throws IOException
      * @throws org.xml.sax.SAXException if invalid UTF-16 surrogate detected.
      */
     protected int writeUTF16Surrogate(char c, char ch[], int i, int end)
-        throws IOException
+        throws IOException, SAXException
     {
-        int codePoint = 0;
+        int status = -1;
         if (i + 1 >= end)
         {
-            throw new IOException(
-                Utils.messages.createMessage(
-                    MsgKey.ER_INVALID_UTF16_SURROGATE,
-                    new Object[] { Integer.toHexString((int) c)}));
+            m_highSurrogate = c;
+            return status;
+        }
+
+        char high, low;
+        if (m_highSurrogate == 0) {
+            high = c;
+            low = ch[i+1];
+            status = 0;
+        } else {
+            high = m_highSurrogate;
+            low = c;
+            m_highSurrogate = 0;
         }
         
-        final char high = c;
-        final char low = ch[i+1];
         if (!Encodings.isLowUTF16Surrogate(low)) {
-            throw new IOException(
-                Utils.messages.createMessage(
-                    MsgKey.ER_INVALID_UTF16_SURROGATE,
-                    new Object[] {
-                        Integer.toHexString((int) c)
-                            + " "
-                            + Integer.toHexString(low)}));
+            throwIOE(high, low);
         }
 
         final java.io.Writer writer = m_writer;
                 
         // If we make it to here we have a valid high, low surrogate pair
-        if (m_encodingInfo.isInEncoding(c,low)) {
+        if (m_encodingInfo.isInEncoding(high,low)) {
             // If the character formed by the surrogate pair
             // is in the encoding, so just write it out
-            writer.write(ch,i,2);
+            writer.write(new char[]{high, low}, 0, 2);
         }
         else {
             // Don't know what to do with this char, it is
@@ -1017,24 +1019,16 @@ abstract public class ToStream extends SerializerBase
             // a surrogate pair, so write out as an entity ref
             final String encoding = getEncoding();
             if (encoding != null) {
-                /* The output encoding is known, 
-                 * so somthing is wrong.
-                  */
-                codePoint = Encodings.toCodePoint(high, low);
-                // not in the encoding, so write out a character reference
-                writer.write('&');
-                writer.write('#');
-                writer.write(Integer.toString(codePoint));
-                writer.write(';');
+                status = writeCharRef(writer, high, low);
             } else {
                 /* The output encoding is not known,
                  * so just write it out as-is.
                  */
-                writer.write(ch, i, 2);
+                writer.write(new char[]{high, low}, 0, 2);
             }
         }
         // non-zero only if character reference was written out.
-        return codePoint;
+        return status;
     }
 
     /**
@@ -1124,32 +1118,7 @@ abstract public class ToStream extends SerializerBase
             }
             else if (isCData && (!escapingNotNeeded(c)))
             {
-                //                if (i != 0)
-                if (m_cdataTagOpen)
-                    closeCDATA();
-
-                // This needs to go into a function... 
-                if (Encodings.isHighUTF16Surrogate(c))
-                {
-                    writeUTF16Surrogate(c, ch, i, end);
-                    i++ ; // process two input characters
-                }
-                else
-                {
-                    writer.write("&#");
-
-                    String intStr = Integer.toString((int) c);
-
-                    writer.write(intStr);
-                    writer.write(';');
-                }
-
-                //                if ((i != 0) && (i < (end - 1)))
-                //                if (!m_cdataTagOpen && (i < (end - 1)))
-                //                {
-                //                    writer.write(CDATA_DELIMITER_OPEN);
-                //                    m_cdataTagOpen = true;
-                //                }
+                i = handleEscaping(writer, c, ch, i, end);
             }
             else if (
                 isCData
@@ -1173,29 +1142,44 @@ abstract public class ToStream extends SerializerBase
                     }
                     writer.write(c);
                 }
-
-                // This needs to go into a function... 
-                else if (Encodings.isHighUTF16Surrogate(c))
-                {
-                    if (m_cdataTagOpen)
-                        closeCDATA();
-                    writeUTF16Surrogate(c, ch, i, end);
-                    i++; // process two input characters
-                }
-                else
-                {
-                    if (m_cdataTagOpen)
-                        closeCDATA();
-                    writer.write("&#");
-
-                    String intStr = Integer.toString((int) c);
-
-                    writer.write(intStr);
-                    writer.write(';');
+                else {
+                    i = handleEscaping(writer, c, ch, i, end);
                 }
             }
         }
 
+    }
+
+    /**
+     * Handles escaping, writes either with a surrogate pair or a character
+     * reference.
+     *
+     * @param c the current char
+     * @param ch the character array
+     * @param i the current position
+     * @param end the end index of the array
+     * @return the next index
+     *
+     * @throws IOException
+     * @throws org.xml.sax.SAXException if invalid UTF-16 surrogate detected.
+     */
+    private int handleEscaping(Writer writer, char c, char ch[], int i, int end)
+            throws IOException, SAXException {
+        if (Encodings.isHighUTF16Surrogate(c) || Encodings.isLowUTF16Surrogate(c))
+        {
+            if (writeUTF16Surrogate(c, ch, i, end) >= 0) {
+                // move the index if the low surrogate is consumed
+                // as writeUTF16Surrogate has written the pair
+                if (Encodings.isHighUTF16Surrogate(c)) {
+                    i++ ;
+                }
+            }
+        }
+        else
+        {
+            writeCharRef(writer, c);
+        }
+        return i;
     }
 
     /**
@@ -1266,7 +1250,7 @@ abstract public class ToStream extends SerializerBase
             }
             m_ispreserve = true;
 
-            if (shouldIndent())
+            if (!m_cdataTagOpen && shouldIndent())
                 indent();
 
             boolean writeCDataBrackets =
@@ -1715,7 +1699,7 @@ abstract public class ToStream extends SerializerBase
         int i, 
         char ch,
         int lastDirty,
-        boolean fromTextNode) throws IOException
+        boolean fromTextNode) throws IOException, SAXException
     {
         int startClean = lastDirty + 1;
         // if we have some clean characters accumulated
@@ -1794,54 +1778,41 @@ abstract public class ToStream extends SerializerBase
         int len,
         boolean fromTextNode,
         boolean escLF)
-        throws IOException
+        throws IOException, SAXException
     {
 
         int pos = accumDefaultEntity(writer, ch, i, chars, len, fromTextNode, escLF);
 
         if (i == pos)
         {
+            if (m_highSurrogate != 0) {
+                if (!(Encodings.isLowUTF16Surrogate(ch))) {
+                    throwIOE(m_highSurrogate, ch);
+                }
+                writeCharRef(writer, m_highSurrogate, ch);
+                m_highSurrogate = 0;
+                return ++pos;
+            }
+
             if (Encodings.isHighUTF16Surrogate(ch))
             {
-
-                // Should be the UTF-16 low surrogate of the hig/low pair.
-                char next;
-                // Unicode code point formed from the high/low pair.
-                int codePoint = 0;
-
                 if (i + 1 >= len)
                 {
-                    throw new IOException(
-                        Utils.messages.createMessage(
-                            MsgKey.ER_INVALID_UTF16_SURROGATE,
-                            new Object[] { Integer.toHexString(ch)}));
-                    //"Invalid UTF-16 surrogate detected: "
-
-                    //+Integer.toHexString(ch)+ " ?");
+                    // save for the next read
+                    m_highSurrogate = ch;
+                    pos++;
                 }
                 else
                 {
-                    next = chars[++i];
+                    // the next should be the UTF-16 low surrogate of the hig/low pair.
+                    char next = chars[++i];
 
                     if (!(Encodings.isLowUTF16Surrogate(next)))
-                        throw new IOException(
-                            Utils.messages.createMessage(
-                                MsgKey
-                                    .ER_INVALID_UTF16_SURROGATE,
-                                new Object[] {
-                                    Integer.toHexString(ch)
-                                        + " "
-                                        + Integer.toHexString(next)}));
-                    //"Invalid UTF-16 surrogate detected: "
+                        throwIOE(ch, next);
 
-                    //+Integer.toHexString(ch)+" "+Integer.toHexString(next));
-                    codePoint = Encodings.toCodePoint(ch,next);
+                    writeCharRef(writer, ch, next);
+                    pos += 2; // count the two characters that went into writing out this entity
                 }
-
-                writer.write("&#");
-                writer.write(Integer.toString(codePoint));
-                writer.write(';');
-                pos += 2; // count the two characters that went into writing out this entity
             }
             else
             {
@@ -1852,18 +1823,14 @@ abstract public class ToStream extends SerializerBase
                  */ 
                 if (isCharacterInC0orC1Range(ch) || isNELorLSEPCharacter(ch))
                 {
-                    writer.write("&#");
-                    writer.write(Integer.toString(ch));
-                    writer.write(';');
+                    writeCharRef(writer, ch);
                 }
                 else if ((!escapingNotNeeded(ch) || 
                     (  (fromTextNode && m_charInfo.shouldMapTextChar(ch))
                      || (!fromTextNode && m_charInfo.shouldMapAttrChar(ch)))) 
-                && m_elemContext.m_currentElemDepth > 0)
+		    && m_elemContext.m_currentElemDepth > 0)
                 {
-                    writer.write("&#");
-                    writer.write(Integer.toString(ch));
-                    writer.write(';');
+                    writeCharRef(writer, ch);
                 }
                 else
                 {
@@ -1874,6 +1841,45 @@ abstract public class ToStream extends SerializerBase
 
         }
         return pos;
+    }
+
+    /**
+     * Writes out a character reference.
+     * @param writer the writer
+     * @param c the character
+     * @throws IOException
+     */
+    private void writeCharRef(Writer writer, char c) throws IOException, SAXException {
+        if (m_cdataTagOpen)
+            closeCDATA();
+        writer.write("&#");
+        writer.write(Integer.toString(c));
+        writer.write(';');
+    }
+
+    /**
+     * Writes out a pair of surrogates as a character reference
+     * @param writer the writer
+     * @param high the high surrogate
+     * @param low the low surrogate
+     * @throws IOException
+     */
+    private int writeCharRef(Writer writer, char high, char low) throws IOException, SAXException {
+        if (m_cdataTagOpen)
+            closeCDATA();
+        // Unicode code point formed from the high/low pair.
+        int codePoint = Encodings.toCodePoint(high, low);
+        writer.write("&#");
+        writer.write(Integer.toString(codePoint));
+        writer.write(';');
+        return codePoint;
+    }
+
+    private void throwIOE(char ch, char next) throws IOException {
+        throw new IOException(Utils.messages.createMessage(
+                MsgKey.ER_INVALID_UTF16_SURROGATE,
+                new Object[] {Integer.toHexString(ch) + " "
+                        + Integer.toHexString(next)}));
     }
 
     /**
@@ -2100,7 +2106,7 @@ abstract public class ToStream extends SerializerBase
         Writer writer,
         String string,
         String encoding)
-        throws IOException
+        throws IOException, SAXException
     {
         final int len = string.length();
         if (len > m_attrBuff.length)


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8207760

Applies patches listed here:
http://cr.openjdk.java.net/~phh/8207760/webrev.8u.jaxp.00/

Disclaimer:
Not really positive that the patches were applied correctly because they were based on the JDK versions of xalan-j, and since we don't have any tests for safety, I would be apprehensive about merging this in. In fact, perhaps it isn't really necessary because the condition where it would occur is rarely met.